### PR TITLE
Redesign personal site with modern layout and animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/animations.js
+++ b/animations.js
@@ -1,0 +1,23 @@
+// Scroll-triggered fade-in animations using Intersection Observer
+document.addEventListener('DOMContentLoaded', () => {
+  const targets = document.querySelectorAll('.animate-on-scroll');
+
+  if (!targets.length) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    {
+      threshold: 0.15,
+      rootMargin: '0px 0px -40px 0px',
+    }
+  );
+
+  targets.forEach((el) => observer.observe(el));
+});

--- a/animations.js
+++ b/animations.js
@@ -1,5 +1,24 @@
-// Scroll-triggered fade-in animations using Intersection Observer
+// Theme toggle — respects OS preference, remembers user choice
+(function () {
+  const saved = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const theme = saved || (prefersDark ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', theme);
+})();
+
 document.addEventListener('DOMContentLoaded', () => {
+  // Theme toggle button
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+    });
+  }
+
+  // Scroll-triggered fade-in animations using Intersection Observer
   const targets = document.querySelectorAll('.animate-on-scroll');
 
   if (!targets.length) return;

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Ethan Chen</title>
     <meta name="author" content="Ethan Chen" />
-    <meta name="description" content="Ethan Chen — M.S. CS at UC San Diego. Research in Vision-Language-Action models. ICLR 2025, SIGCSE 2025." />
+    <meta name="description" content="Ethan Chen — M.S. CSE at UC San Diego. AI Engineering. ICLR 2025, SIGCSE 2025." />
     <meta property="og:title" content="Ethan Chen" />
-    <meta property="og:description" content="M.S. CS at UC San Diego. Research in Vision-Language-Action models." />
+    <meta property="og:description" content="M.S. CSE at UC San Diego. AI Engineering." />
     <meta property="og:image" content="images/profile_photo_cropped.jpeg" />
     <meta property="og:type" content="website" />
     <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
@@ -19,12 +19,10 @@
       <header class="hero">
         <div class="hero-text">
           <p class="name">Ethan Chen</p>
-          <p class="tagline">M.S. CS @ UCSD · Vision-Language-Action Research</p>
+          <p class="tagline">M.S. CSE @ UCSD</p>
           <p class="bio">
-            I'm currently pursuing my M.S. in Computer Science and Engineering at UC
-            San Diego. I do research in Vision-Language-Action models at the
-            <a href="https://avl.ucsd.edu">Autonomous Vehicle Lab</a>, supervised by
-            Professor Henrik Christensen.
+            Hi, I'm currently pursuing my M.S. in Computer Science and Engineering at UC
+            San Diego.
           </p>
           <p class="bio">
             I graduated with a Bachelor's in CS and Statistics from UC Berkeley in May
@@ -51,7 +49,7 @@
         <div class="experience-list">
           <div class="experience-item">
             <div>
-              <span class="role">Member of Technical Staff Intern</span>
+              <span class="role">Machine Learning Engineer Intern</span>
               <span class="company"> · <a href="https://www.kognitos.com/">Kognitos</a> (Series B)</span>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -54,12 +54,16 @@
             <div>
               <span class="role">Machine Learning Engineer Intern</span>
               <span class="company"> · <a href="https://www.kognitos.com/">Kognitos</a> (Series B)</span>
+              <span class="experience-date">May – Aug 2025</span>
+              <p class="experience-desc">Built an evaluation platform for agentic AI models using DeepEval, RAGAS, and LLM-as-a-judge. Designed scalable pipelines to benchmark OCR and LLM variants across 100+ tasks.</p>
             </div>
           </div>
           <div class="experience-item">
             <div>
               <span class="role">Software Development Engineer Intern</span>
               <span class="company"> · <a href="https://aws.amazon.com/sagemaker">Amazon SageMaker</a></span>
+              <span class="experience-date">May – Aug 2024</span>
+              <p class="experience-desc">Built full-stack systems for SageMaker Canvas to monitor and control ML training workflows with 250+ model candidates, enabling real-time observability.</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 
   <body>
     <div class="container">
+      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+        <span class="theme-toggle-icon"></span>
+      </button>
       <header class="hero animate-on-scroll">
         <div class="hero-text">
           <p class="name">Ethan Chen</p>

--- a/index.html
+++ b/index.html
@@ -16,13 +16,16 @@
 
   <body>
     <div class="container">
-      <header class="hero">
+      <header class="hero animate-on-scroll">
         <div class="hero-text">
           <p class="name">Ethan Chen</p>
           <p class="tagline">M.S. CSE @ UCSD</p>
           <p class="bio">
             Hi, I'm currently pursuing my M.S. in Computer Science and Engineering at UC
-            San Diego.
+            San Diego. I'm broadly interested in applied AI, large language models, and
+            agentic systems. Specifically, I'm interested in building AI agents that
+            reliably perform complex, domain-specific tasks, and the evaluation
+            frameworks needed to trust them at scale.
           </p>
           <p class="bio">
             I graduated with a Bachelor's in CS and Statistics from UC Berkeley in May
@@ -44,7 +47,7 @@
         </div>
       </header>
 
-      <section>
+      <section class="animate-on-scroll">
         <h2 class="section-heading">Experience</h2>
         <div class="experience-list">
           <div class="experience-item">
@@ -62,7 +65,7 @@
         </div>
       </section>
 
-      <section>
+      <section class="animate-on-scroll">
         <h2 class="section-heading">Research</h2>
 
         <div class="paper">
@@ -104,7 +107,7 @@
         </div>
       </section>
 
-      <section>
+      <section class="animate-on-scroll">
         <h2 class="section-heading">Computer Vision Projects</h2>
         <div class="projects-grid">
 
@@ -164,5 +167,6 @@
         <a href="https://github.com/jonbarron/jonbarron.github.io">Jon Barron</a>.
       </footer>
     </div>
+    <script src="animations.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,219 +1,170 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-
-    <title>Ethan Chen</title>
-
-    <meta name="author" content="Ethan Chen" />
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ethan Chen</title>
+    <meta name="author" content="Ethan Chen" />
+    <meta name="description" content="Ethan Chen — M.S. CS at UC San Diego. Research in Vision-Language-Action models. ICLR 2025, SIGCSE 2025." />
+    <meta property="og:title" content="Ethan Chen" />
+    <meta property="og:description" content="M.S. CS at UC San Diego. Research in Vision-Language-Action models." />
+    <meta property="og:image" content="images/profile_photo_cropped.jpeg" />
+    <meta property="og:type" content="website" />
     <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" type="text/css" href="stylesheet.css" />
+    <link rel="stylesheet" href="stylesheet.css" />
   </head>
 
   <body>
-    <table
-      style="
-        width: 100%;
-        max-width: 800px;
-        border: 0px;
-        border-spacing: 0px;
-        border-collapse: separate;
-        margin-right: auto;
-        margin-left: auto;
-      "
-    >
-      <tbody>
-        <tr style="padding: 0px">
-          <td style="padding: 0px">
-            <table
-              style="
-                width: 100%;
-                border: 0px;
-                border-spacing: 0px;
-                border-collapse: separate;
-                margin-right: auto;
-                margin-left: auto;
-              "
-            >
-              <tbody>
-                <tr style="padding: 0px">
-                  <td style="padding: 2.5%; width: 63%; vertical-align: middle">
-                    <p class="name" style="text-align: center">Ethan Chen</p>
-                    <p>
-                      Hi, I'm currently pursuing my M.S. in Computer Science and Engineering at UC
-                      San Diego. I do research in Vision-Language-Action models at the
-                      <a href="https://avl.ucsd.edu">Autonomous Vehicle Lab</a>, supervised by
-                      Professor Henrik Christensen. <br />
-                      <br />
-                      I graduated with a Bachelor's in CS and Statistics from UC Berkeley in May
-                      2025. There, I did research at the
-                      <a href="https://bair.berkeley.edu/"
-                        >Berkeley Artificial Intelligence Research Lab</a
-                      >, where I was advised by Professor Gopala Anumanchipalli. <br /><br />
-                      I've had the opportunity to work at
-                      <a href="https://www.kognitos.com/">Kognitos</a> (Series B) as a Member of
-                      Technical Staff Intern and at
-                      <a href="https://aws.amazon.com/sagemaker">Amazon SageMaker</a>, as a Software
-                      Development Engineer Intern.
-                    </p>
-                    <p style="text-align: center">
-                      <a href="mailto:etc009@usd.edu">Email</a> &nbsp;/&nbsp;
-                      <a href="https://www.linkedin.com/in/ethan-c-chen/">LinkedIn</a> &nbsp;/&nbsp;
-                      <a href="https://scholar.google.com/citations?hl=en&user=RXSNqXoAAAAJ"
-                        >Google Scholar</a
-                      >
-                      &nbsp;/&nbsp;
-                      <a href="https://github.com/ethancchen/">GitHub</a>
-                    </p>
-                  </td>
-                  <td style="padding: 2.5%; width: 37%; max-width: 37%">
-                    <a href="images/profile_photo_cropped.jpeg"
-                      ><img
-                        style="width: 100%; max-width: 100%; object-fit: cover; border-radius: 0"
-                        alt="profile photo"
-                        src="images/profile_photo_cropped.jpeg"
-                        class="hoverZoomLink"
-                    /></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <table
-              style="
-                width: 100%;
-                border: 0px;
-                border-spacing: 0px;
-                border-collapse: separate;
-                margin-right: auto;
-                margin-left: auto;
-              "
-            >
-              <tbody>
-                <tr>
-                  <td style="padding: 16px; width: 100%; vertical-align: middle">
-                    <h2>Research</h2>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <table
-              style="
-                width: 100%;
-                border: 0px;
-                border-spacing: 0px 10px;
-                border-collapse: separate;
-                margin-right: auto;
-                margin-left: auto;
-              "
-            >
-              <tbody>
-                <tr>
-                  <td style="padding: 16px; width: 20%; vertical-align: middle">
-                    <img src="images/sylber.png" width="160" />
-                  </td>
-                  <td style="padding: 8px; width: 80%; vertical-align: middle">
-                    <a href="https://arxiv.org/abs/2410.07168">
-                      <span class="papertitle"
-                        >Sylber: Syllabic Embedding Representation of Speech from Raw Audio</span
-                      >
-                    </a>
-                    <br />
-                    Cheol Jun Cho, Nicholas Lee, Akshat Gupta, Dhruv Agarwal,
-                    <strong>Ethan Chen</strong>, Alan W. Black, Gopala Anumanchipalli
-                    <br />
-                    <em>ICLR</em>, 2025
-                    <br />
-                    <a href="https://github.com/Berkeley-Speech-Group/sylber">code</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding: 16px; width: 20%; vertical-align: middle">
-                    <img src="images/llm-kci.png" width="160" />
-                  </td>
-                  <td style="padding: 8px; width: 80%; vertical-align: middle">
-                    <a
-                      href="https://sigcse2025.sigcse.org/details/sigcse-ts-2025-posters/54/LLM-KCI-Leveraging-Large-Language-Models-to-Identify-Programming-Knowledge-Component"
-                    >
-                      <span class="papertitle"
-                        >LLM-KCI: Leveraging Large Language Models to Identify Programming Knowledge
-                        Components</span
-                      >
-                    </a>
-                    <br />
-                    Rose Niousha, Abigail O'Neill*, <strong>Ethan Chen</strong>*, Vedansh Malhotra,
-                    Bita Akram, Narges Norouzi
-                    <br />
-                    <em>SIGCSE TS Posters</em>, 2025
-                    <br />
-                    <a href="https://dl.acm.org/doi/10.1145/3641555.3705215">conference poster</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+    <div class="container">
+      <header class="hero">
+        <div class="hero-text">
+          <p class="name">Ethan Chen</p>
+          <p class="tagline">M.S. CS @ UCSD · Vision-Language-Action Research</p>
+          <p class="bio">
+            I'm currently pursuing my M.S. in Computer Science and Engineering at UC
+            San Diego. I do research in Vision-Language-Action models at the
+            <a href="https://avl.ucsd.edu">Autonomous Vehicle Lab</a>, supervised by
+            Professor Henrik Christensen.
+          </p>
+          <p class="bio">
+            I graduated with a Bachelor's in CS and Statistics from UC Berkeley in May
+            2025. There, I did research at the
+            <a href="https://bair.berkeley.edu/">Berkeley Artificial Intelligence Research Lab</a>,
+            where I was advised by Professor Gopala Anumanchipalli.
+          </p>
+          <div class="contact-links">
+            <a href="mailto:etc009@usd.edu">Email</a>
+            <a href="https://www.linkedin.com/in/ethan-c-chen/">LinkedIn</a>
+            <a href="https://scholar.google.com/citations?hl=en&user=RXSNqXoAAAAJ">Google Scholar</a>
+            <a href="https://github.com/ethancchen/">GitHub</a>
+          </div>
+        </div>
+        <div class="hero-photo">
+          <a href="images/profile_photo_cropped.jpeg">
+            <img src="images/profile_photo_cropped.jpeg" alt="Ethan Chen profile photo" />
+          </a>
+        </div>
+      </header>
 
-            <table style="width: 100%; margin: 0 auto; border: 0; border-spacing: 0; padding: 16px">
-              <tbody>
-                <tr>
-                  <td>
-                    <h2>Computer Vision Projects</h2>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <table
-              style="
-                width: 100%;
-                border: 0px;
-                border-spacing: 0px;
-                border-collapse: separate;
-                margin-right: auto;
-                margin-left: auto;
-              "
-            >
-              <tbody>
-                <tr>
-                  <td align="left" style="padding: 16px; width: 20%; vertical-align: middle">
-                    <a href="cv_proj/1/index.html">Project 1</a>
-                    <br />
-                    <a href="cv_proj/2/index.html">Project 2</a>
-                    <br />
-                    <a href="cv_proj/3/index.html">Project 3</a>
-                    <br />
-                    <a href="cv_proj/4/index.html">Project 4</a>
-                    <br />
-                    <a href="cv_proj/5/index.html">Project 5</a>
-                    <br />
-                    <a href="cv_proj/final_proj/index.html">Final Project</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      style="
-        width: 100%;
-        border: 0px;
-        border-spacing: 0px;
-        border-collapse: separate;
-        margin-right: auto;
-        margin-left: auto;
-      "
-    >
-      <tbody>
-        <tr>
-          <td style="padding: 0px">
-            <br />
-            <p style="text-align: right; font-size: small">
-              Website template from
-              <a href="https://github.com/jonbarron/jonbarron.github.io">here</a>.
-            </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <section>
+        <h2 class="section-heading">Experience</h2>
+        <div class="experience-list">
+          <div class="experience-item">
+            <div>
+              <span class="role">Member of Technical Staff Intern</span>
+              <span class="company"> · <a href="https://www.kognitos.com/">Kognitos</a> (Series B)</span>
+            </div>
+          </div>
+          <div class="experience-item">
+            <div>
+              <span class="role">Software Development Engineer Intern</span>
+              <span class="company"> · <a href="https://aws.amazon.com/sagemaker">Amazon SageMaker</a></span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-heading">Research</h2>
+
+        <div class="paper">
+          <div class="paper-thumb">
+            <img src="images/sylber.png" alt="Sylber paper figure" />
+          </div>
+          <div class="paper-info">
+            <a href="https://arxiv.org/abs/2410.07168">
+              <span class="paper-title">Sylber: Syllabic Embedding Representation of Speech from Raw Audio</span>
+            </a>
+            <div class="paper-authors">
+              Cheol Jun Cho, Nicholas Lee, Akshat Gupta, Dhruv Agarwal,
+              <strong>Ethan Chen</strong>, Alan W. Black, Gopala Anumanchipalli
+            </div>
+            <span class="paper-venue">ICLR, 2025</span>
+            <div class="paper-links">
+              <a href="https://github.com/Berkeley-Speech-Group/sylber">code</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="paper">
+          <div class="paper-thumb">
+            <img src="images/llm-kci.png" alt="LLM-KCI paper figure" />
+          </div>
+          <div class="paper-info">
+            <a href="https://sigcse2025.sigcse.org/details/sigcse-ts-2025-posters/54/LLM-KCI-Leveraging-Large-Language-Models-to-Identify-Programming-Knowledge-Component">
+              <span class="paper-title">LLM-KCI: Leveraging Large Language Models to Identify Programming Knowledge Components</span>
+            </a>
+            <div class="paper-authors">
+              Rose Niousha, Abigail O'Neill*, <strong>Ethan Chen</strong>*, Vedansh Malhotra,
+              Bita Akram, Narges Norouzi
+            </div>
+            <span class="paper-venue">SIGCSE TS Posters, 2025</span>
+            <div class="paper-links">
+              <a href="https://dl.acm.org/doi/10.1145/3641555.3705215">conference poster</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-heading">Computer Vision Projects</h2>
+        <div class="projects-grid">
+
+          <a href="cv_proj/final_proj/index.html" class="project-card">
+            <img src="cv_proj/final_proj/media/lego_white.gif" alt="NeRF rendered lego scene" />
+            <div class="project-card-body">
+              <p class="project-card-title">Neural Radiance Fields</p>
+              <p class="project-card-desc">Fit neural fields to 2D images and multi-view 3D scenes with volumetric rendering.</p>
+            </div>
+          </a>
+
+          <a href="cv_proj/5/index.html" class="project-card">
+            <img src="cv_proj/5/media/part_b/cc_5_epochs_sample.png" alt="Diffusion model output" />
+            <div class="project-card-body">
+              <p class="project-card-title">Diffusion Models</p>
+              <p class="project-card-desc">Text-conditioned image generation and single-step denoising.</p>
+            </div>
+          </a>
+
+          <a href="cv_proj/4/index.html" class="project-card">
+            <img src="cv_proj/4/media/output_images/blake_facing_north_right_to_middle_mosaic_manual.jpg" alt="Photo mosaic stitching" />
+            <div class="project-card-body">
+              <p class="project-card-title">Auto-Stitching Photo Mosaics</p>
+              <p class="project-card-desc">Homography estimation, image warping, and seamless blending for panoramas.</p>
+            </div>
+          </a>
+
+          <a href="cv_proj/3/index.html" class="project-card">
+            <img src="cv_proj/3/media/bells_and_whistles/warped_asian_male_to_ethan_geometry.jpg" alt="Face morphing result" />
+            <div class="project-card-body">
+              <p class="project-card-title">Face Morphing &amp; Caricatures</p>
+              <p class="project-card-desc">Delaunay triangulation, affine warps, and cross-dissolve for face transformations.</p>
+            </div>
+          </a>
+
+          <a href="cv_proj/2/index.html" class="project-card">
+            <img src="cv_proj/2/media/part22/22_nutmeg_aligned_grayscale_DerekPicture_aligned_regular_hybrid_image.jpg" alt="Hybrid image of cat and person" />
+            <div class="project-card-body">
+              <p class="project-card-title">Filters &amp; Frequencies</p>
+              <p class="project-card-desc">Gaussian and Laplacian stacks, hybrid images, and multi-resolution blending.</p>
+            </div>
+          </a>
+
+          <a href="cv_proj/1/index.html" class="project-card">
+            <img src="cv_proj/1/media/pyramid_aligned/self_portrait_pyramid_aligned.jpg" alt="Colorized Russian empire photograph" />
+            <div class="project-card-body">
+              <p class="project-card-title">Image Alignment</p>
+              <p class="project-card-desc">Aligning and colorizing digitized Prokudin-Gorsky glass plate negatives.</p>
+            </div>
+          </a>
+
+        </div>
+      </section>
+
+      <footer>
+        Website template inspired by
+        <a href="https://github.com/jonbarron/jonbarron.github.io">Jon Barron</a>.
+      </footer>
+    </div>
   </body>
 </html>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,4 +1,339 @@
-/* latin-ext */
+/* ========================================
+   Ethan Chen — Personal Website Styles
+   ======================================== */
+
+/* --- Custom Properties --- */
+:root {
+  --color-bg: #ffffff;
+  --color-text: #333333;
+  --color-text-secondary: #666666;
+  --color-link: #1772d0;
+  --color-link-hover: #f09228;
+  --color-border: #e5e7eb;
+  --color-card-bg: #f9fafb;
+  --color-highlight: #ffffd0;
+  --color-venue: #1a5276;
+
+  --font-sans: 'Lato', Verdana, Helvetica, sans-serif;
+  --font-size-base: 15px;
+  --font-size-sm: 13px;
+  --font-size-lg: 18px;
+  --font-size-xl: 22px;
+  --font-size-name: 32px;
+
+  --line-height: 1.6;
+  --max-width: 820px;
+  --section-gap: 48px;
+  --border-radius: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1a1a2e;
+    --color-text: #e0e0e0;
+    --color-text-secondary: #a0a0a0;
+    --color-link: #5ba3e6;
+    --color-link-hover: #f09228;
+    --color-border: #2d2d44;
+    --color-card-bg: #22223a;
+    --color-venue: #7fb3d8;
+  }
+}
+
+/* --- Reset & Base --- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- Layout --- */
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+}
+
+/* --- Links --- */
+a {
+  color: var(--color-link);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-link-hover);
+}
+
+/* --- Headings --- */
+h2.section-heading {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-xl);
+  font-weight: 400;
+  color: var(--color-text);
+  margin: 0 0 24px 0;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--color-border);
+}
+
+section {
+  margin-bottom: var(--section-gap);
+}
+
+/* --- Hero / Header --- */
+.hero {
+  display: flex;
+  gap: 32px;
+  align-items: center;
+  margin-bottom: var(--section-gap);
+  padding-top: 32px;
+}
+
+.hero-text {
+  flex: 1;
+}
+
+.hero-photo {
+  flex-shrink: 0;
+}
+
+.hero-photo img {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.name {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-name);
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  text-align: center;
+}
+
+.tagline {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  text-align: center;
+  margin: 0 0 16px 0;
+}
+
+.bio {
+  margin: 0 0 16px 0;
+}
+
+.contact-links {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.contact-links a {
+  padding: 4px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  font-size: var(--font-size-sm);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.contact-links a:hover {
+  border-color: var(--color-link-hover);
+}
+
+@media (max-width: 600px) {
+  .hero {
+    flex-direction: column-reverse;
+    text-align: center;
+  }
+
+  .hero-photo img {
+    width: 160px;
+    height: 160px;
+  }
+}
+
+/* --- Research Papers --- */
+.paper {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  border-radius: var(--border-radius);
+  transition: background-color 0.2s ease;
+}
+
+.paper:hover {
+  background-color: var(--color-card-bg);
+}
+
+.paper-thumb {
+  flex-shrink: 0;
+  width: 160px;
+  align-self: center;
+}
+
+.paper-thumb img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.paper-info {
+  flex: 1;
+}
+
+.paper-title {
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  font-family: var(--font-sans);
+}
+
+.paper-authors {
+  margin-top: 4px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.paper-venue {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  color: var(--color-venue);
+}
+
+.paper-links {
+  margin-top: 6px;
+  font-size: var(--font-size-sm);
+}
+
+.paper-links a + a {
+  margin-left: 12px;
+}
+
+@media (max-width: 600px) {
+  .paper {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .paper-thumb {
+    width: 120px;
+  }
+}
+
+/* --- Project Cards --- */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+.project-card {
+  display: block;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+  color: var(--color-text);
+}
+
+.project-card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+
+.project-card-body {
+  padding: 12px 16px 16px;
+}
+
+.project-card-title {
+  font-weight: 700;
+  font-size: var(--font-size-base);
+  margin: 0 0 4px;
+}
+
+.project-card-desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+@media (max-width: 600px) {
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* --- Experience --- */
+.experience-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.experience-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 12px 16px;
+  border-radius: var(--border-radius);
+  background-color: var(--color-card-bg);
+}
+
+.experience-item .role {
+  font-weight: 700;
+}
+
+.experience-item .company {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 600px) {
+  .experience-item {
+    flex-direction: column;
+    gap: 2px;
+  }
+}
+
+/* --- Footer --- */
+footer {
+  text-align: right;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  padding-top: 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+/* --- Utilities --- */
+span.highlight {
+  background-color: var(--color-highlight);
+}
+
+/* --- Lato Font Faces --- */
 @font-face {
   font-family: 'Lato';
   font-style: italic;
@@ -6,7 +341,7 @@
   src: local('Lato Italic'), local('Lato-Italic'), url(https://fonts.gstatic.com/s/lato/v15/S6u8w4BMUTPHjxsAUi-qNiXg7eU0.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
+
 @font-face {
   font-family: 'Lato';
   font-style: italic;
@@ -14,7 +349,7 @@
   src: local('Lato Italic'), local('Lato-Italic'), url(https://fonts.gstatic.com/s/lato/v15/S6u8w4BMUTPHjxsAXC-qNiXg7Q.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
-/* latin-ext */
+
 @font-face {
   font-family: 'Lato';
   font-style: italic;
@@ -22,7 +357,7 @@
   src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url(https://fonts.gstatic.com/s/lato/v15/S6u_w4BMUTPHjxsI5wq_FQftx9897sxZ.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
+
 @font-face {
   font-family: 'Lato';
   font-style: italic;
@@ -30,7 +365,7 @@
   src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url(https://fonts.gstatic.com/s/lato/v15/S6u_w4BMUTPHjxsI5wq_Gwftx9897g.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
-/* latin-ext */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;
@@ -38,7 +373,7 @@
   src: local('Lato Regular'), local('Lato-Regular'), url(https://fonts.gstatic.com/s/lato/v15/S6uyw4BMUTPHjxAwXiWtFCfQ7A.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;
@@ -46,7 +381,7 @@
   src: local('Lato Regular'), local('Lato-Regular'), url(https://fonts.gstatic.com/s/lato/v15/S6uyw4BMUTPHjx4wXiWtFCc.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
-/* latin-ext */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;
@@ -54,89 +389,11 @@
   src: local('Lato Bold'), local('Lato-Bold'), url(https://fonts.gstatic.com/s/lato/v15/S6u9w4BMUTPHh6UVSwaPGQ3q5d0N7w.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 700;
   src: local('Lato Bold'), local('Lato-Bold'), url(https://fonts.gstatic.com/s/lato/v15/S6u9w4BMUTPHh6UVSwiPGQ3q5d0.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-a {
-  color: #1772d0;
-  text-decoration: none;
-}
-
-a:focus,
-a:hover {
-  color: #f09228;
-  text-decoration: none;
-}
-
-body,
-td,
-th,
-tr,
-p,
-a {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px;
-}
-
-strong {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px;
-}
-
-h2 {
-  margin: 0;
-  font-weight: normal;
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 22px;
-}
-
-.papertitle {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.name {
-  padding-top: 20px;
-  margin: 0;
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 32px;
-}
-
-.one {
-  width: 160px;
-  height: 160px;
-  position: relative;
-}
-
-.two {
-  width: 160px;
-  height: 160px;
-  position: absolute;
-  transition: opacity .2s ease-in-out;
-  -moz-transition: opacity .2s ease-in-out;
-  -webkit-transition: opacity .2s ease-in-out;
-}
-
-.fade {
-  transition: opacity .2s ease-in-out;
-  -moz-transition: opacity .2s ease-in-out;
-  -webkit-transition: opacity .2s ease-in-out;
-}
-
-span.highlight {
-  background-color: #ffffd0;
-}
-
-.colored-box {
-    color: black;
-    padding: 20px;
-    display: inline-block;
-    border-radius: 10px;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -30,20 +30,19 @@
   --border-radius: 12px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #0f0f1a;
-    --color-bg-gradient: linear-gradient(135deg, #0f0f1a 0%, #141428 50%, #1a1025 100%);
-    --color-text: #e8e8f0;
-    --color-text-secondary: #9898aa;
-    --color-link: #6b8aff;
-    --color-link-hover: #f09228;
-    --color-border: #252540;
-    --color-card-bg: rgba(30, 30, 55, 0.6);
-    --color-card-border: rgba(60, 60, 100, 0.3);
-    --color-card-shadow: rgba(0, 0, 0, 0.3);
-    --color-venue: #6b8aff;
-  }
+/* Dark mode — applied via class or OS preference */
+[data-theme="dark"] {
+  --color-bg: #0f0f1a;
+  --color-bg-gradient: linear-gradient(135deg, #0f0f1a 0%, #141428 50%, #1a1025 100%);
+  --color-text: #e8e8f0;
+  --color-text-secondary: #9898aa;
+  --color-link: #6b8aff;
+  --color-link-hover: #f09228;
+  --color-border: #252540;
+  --color-card-bg: rgba(30, 30, 55, 0.6);
+  --color-card-border: rgba(60, 60, 100, 0.3);
+  --color-card-shadow: rgba(0, 0, 0, 0.3);
+  --color-venue: #6b8aff;
 }
 
 /* --- Reset & Base --- */
@@ -87,6 +86,42 @@ a {
 a:hover,
 a:focus {
   color: var(--color-link-hover);
+}
+
+/* --- Theme Toggle --- */
+.theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 100;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-card-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  padding: 0;
+}
+
+.theme-toggle:hover {
+  border-color: var(--color-link);
+  transform: scale(1.1);
+  box-shadow: 0 4px 12px var(--color-card-shadow);
+}
+
+.theme-toggle-icon::before {
+  content: '\2600';
+  font-size: 18px;
+}
+
+[data-theme="dark"] .theme-toggle-icon::before {
+  content: '\1F319';
 }
 
 /* --- Headings --- */
@@ -300,10 +335,8 @@ section {
   border-radius: 6px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .paper-venue {
-    background: rgba(107, 138, 255, 0.12);
-  }
+[data-theme="dark"] .paper-venue {
+  background: rgba(107, 138, 255, 0.12);
 }
 
 .paper-links {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -429,6 +429,20 @@ section {
   font-size: var(--font-size-sm);
 }
 
+.experience-date {
+  display: block;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+.experience-desc {
+  margin: 8px 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
 @media (max-width: 600px) {
   .experience-item {
     flex-direction: column;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4,39 +4,45 @@
 
 /* --- Custom Properties --- */
 :root {
-  --color-bg: #ffffff;
-  --color-text: #333333;
-  --color-text-secondary: #666666;
-  --color-link: #1772d0;
+  --color-bg: #fafbff;
+  --color-bg-gradient: linear-gradient(135deg, #fafbff 0%, #f0f4ff 50%, #faf0ff 100%);
+  --color-text: #1a1a2e;
+  --color-text-secondary: #555568;
+  --color-link: #4a6cf7;
   --color-link-hover: #f09228;
-  --color-border: #e5e7eb;
-  --color-card-bg: #f9fafb;
+  --color-border: #e2e4f0;
+  --color-card-bg: rgba(255, 255, 255, 0.7);
+  --color-card-border: rgba(255, 255, 255, 0.5);
+  --color-card-shadow: rgba(74, 108, 247, 0.08);
   --color-highlight: #ffffd0;
-  --color-venue: #1a5276;
+  --color-venue: #4a6cf7;
 
-  --font-sans: 'Lato', Verdana, Helvetica, sans-serif;
+  --font-sans: 'Inter', 'Lato', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-size-base: 15px;
   --font-size-sm: 13px;
   --font-size-lg: 18px;
-  --font-size-xl: 22px;
-  --font-size-name: 32px;
+  --font-size-xl: 24px;
+  --font-size-name: 36px;
 
-  --line-height: 1.6;
-  --max-width: 820px;
-  --section-gap: 48px;
-  --border-radius: 8px;
+  --line-height: 1.7;
+  --max-width: 860px;
+  --section-gap: 56px;
+  --border-radius: 12px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg: #1a1a2e;
-    --color-text: #e0e0e0;
-    --color-text-secondary: #a0a0a0;
-    --color-link: #5ba3e6;
+    --color-bg: #0f0f1a;
+    --color-bg-gradient: linear-gradient(135deg, #0f0f1a 0%, #141428 50%, #1a1025 100%);
+    --color-text: #e8e8f0;
+    --color-text-secondary: #9898aa;
+    --color-link: #6b8aff;
     --color-link-hover: #f09228;
-    --color-border: #2d2d44;
-    --color-card-bg: #22223a;
-    --color-venue: #7fb3d8;
+    --color-border: #252540;
+    --color-card-bg: rgba(30, 30, 55, 0.6);
+    --color-card-border: rgba(60, 60, 100, 0.3);
+    --color-card-shadow: rgba(0, 0, 0, 0.3);
+    --color-venue: #6b8aff;
   }
 }
 
@@ -47,29 +53,35 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   line-height: var(--line-height);
   color: var(--color-text);
-  background-color: var(--color-bg);
+  background: var(--color-bg-gradient);
+  background-attachment: fixed;
   margin: 0;
   padding: 0;
   -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
 }
 
 /* --- Layout --- */
 .container {
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 24px 24px 48px;
+  padding: 32px 28px 64px;
 }
 
 /* --- Links --- */
 a {
   color: var(--color-link);
   text-decoration: none;
-  transition: color 0.2s ease;
+  transition: color 0.25s ease;
 }
 
 a:hover,
@@ -81,24 +93,54 @@ a:focus {
 h2.section-heading {
   font-family: var(--font-sans);
   font-size: var(--font-size-xl);
-  font-weight: 400;
+  font-weight: 600;
   color: var(--color-text);
-  margin: 0 0 24px 0;
-  padding-bottom: 8px;
+  margin: 0 0 28px 0;
+  padding-bottom: 10px;
   border-bottom: 2px solid var(--color-border);
+  letter-spacing: -0.02em;
 }
 
 section {
   margin-bottom: var(--section-gap);
 }
 
+/* --- Scroll Animations --- */
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+              transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.animate-on-scroll.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Staggered delays for project cards */
+.project-card:nth-child(1) { transition-delay: 0s; }
+.project-card:nth-child(2) { transition-delay: 0.08s; }
+.project-card:nth-child(3) { transition-delay: 0.16s; }
+.project-card:nth-child(4) { transition-delay: 0.24s; }
+.project-card:nth-child(5) { transition-delay: 0.32s; }
+.project-card:nth-child(6) { transition-delay: 0.4s; }
+
+/* Staggered delays for experience items */
+.experience-item:nth-child(1) { transition-delay: 0s; }
+.experience-item:nth-child(2) { transition-delay: 0.1s; }
+
+/* Staggered delays for papers */
+.paper:nth-child(1) { transition-delay: 0s; }
+.paper:nth-child(2) { transition-delay: 0.1s; }
+
 /* --- Hero / Header --- */
 .hero {
   display: flex;
-  gap: 32px;
+  gap: 40px;
   align-items: center;
   margin-bottom: var(--section-gap);
-  padding-top: 32px;
+  padding: 48px 0 16px;
 }
 
 .hero-text {
@@ -114,71 +156,103 @@ section {
   height: 200px;
   border-radius: 50%;
   object-fit: cover;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 4px 16px rgba(74, 108, 247, 0.15),
+    0 1px 4px rgba(0, 0, 0, 0.08);
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 0.4s ease;
+}
+
+.hero-photo img:hover {
+  transform: scale(1.04);
+  box-shadow:
+    0 8px 28px rgba(74, 108, 247, 0.2),
+    0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .name {
   font-family: var(--font-sans);
   font-size: var(--font-size-name);
   font-weight: 700;
-  margin: 0 0 4px 0;
+  margin: 0 0 6px 0;
   text-align: center;
+  letter-spacing: -0.03em;
 }
 
 .tagline {
   font-size: var(--font-size-base);
   color: var(--color-text-secondary);
   text-align: center;
-  margin: 0 0 16px 0;
+  margin: 0 0 20px 0;
+  letter-spacing: 0.02em;
 }
 
 .bio {
-  margin: 0 0 16px 0;
+  margin: 0 0 14px 0;
 }
 
 .contact-links {
   display: flex;
   justify-content: center;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: wrap;
-  margin-top: 16px;
+  margin-top: 20px;
 }
 
 .contact-links a {
-  padding: 4px 12px;
+  padding: 6px 16px;
   border: 1px solid var(--color-border);
-  border-radius: 20px;
+  border-radius: 24px;
   font-size: var(--font-size-sm);
-  transition: border-color 0.2s ease, color 0.2s ease;
+  font-weight: 500;
+  background: var(--color-card-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: all 0.25s ease;
 }
 
 .contact-links a:hover {
-  border-color: var(--color-link-hover);
+  border-color: var(--color-link);
+  background: var(--color-link);
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px var(--color-card-shadow);
 }
 
 @media (max-width: 600px) {
   .hero {
     flex-direction: column-reverse;
     text-align: center;
+    gap: 24px;
+    padding-top: 32px;
   }
 
   .hero-photo img {
     width: 160px;
     height: 160px;
   }
+
+  .name {
+    font-size: 28px;
+  }
 }
 
 /* --- Research Papers --- */
 .paper {
   display: flex;
-  gap: 16px;
-  padding: 16px;
+  gap: 20px;
+  padding: 20px;
   border-radius: var(--border-radius);
-  transition: background-color 0.2s ease;
+  border: 1px solid transparent;
+  transition: all 0.3s ease;
 }
 
 .paper:hover {
-  background-color: var(--color-card-bg);
+  background: var(--color-card-bg);
+  border-color: var(--color-card-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 4px 16px var(--color-card-shadow);
 }
 
 .paper-thumb {
@@ -189,7 +263,12 @@ section {
 
 .paper-thumb img {
   width: 100%;
-  border-radius: 4px;
+  border-radius: 8px;
+  transition: transform 0.3s ease;
+}
+
+.paper:hover .paper-thumb img {
+  transform: scale(1.03);
 }
 
 .paper-info {
@@ -203,26 +282,41 @@ section {
 }
 
 .paper-authors {
-  margin-top: 4px;
+  margin-top: 6px;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+  line-height: 1.5;
 }
 
 .paper-venue {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 8px;
+  padding: 2px 10px;
   font-size: var(--font-size-sm);
-  font-style: italic;
+  font-style: normal;
+  font-weight: 600;
   color: var(--color-venue);
+  background: rgba(74, 108, 247, 0.08);
+  border-radius: 6px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .paper-venue {
+    background: rgba(107, 138, 255, 0.12);
+  }
 }
 
 .paper-links {
-  margin-top: 6px;
+  margin-top: 8px;
   font-size: var(--font-size-sm);
 }
 
+.paper-links a {
+  font-weight: 500;
+}
+
 .paper-links a + a {
-  margin-left: 12px;
+  margin-left: 14px;
 }
 
 @media (max-width: 600px) {
@@ -241,44 +335,57 @@ section {
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
+  gap: 22px;
 }
 
 .project-card {
   display: block;
   color: var(--color-text);
-  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-card-border);
   border-radius: var(--border-radius);
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 0.35s ease,
+              border-color 0.3s ease;
 }
 
 .project-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+  transform: translateY(-5px);
+  box-shadow: 0 12px 32px var(--color-card-shadow);
+  border-color: var(--color-link);
   color: var(--color-text);
 }
 
 .project-card img {
   width: 100%;
-  height: 160px;
+  height: 170px;
   object-fit: cover;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.project-card:hover img {
+  transform: scale(1.05);
 }
 
 .project-card-body {
-  padding: 12px 16px 16px;
+  padding: 14px 18px 18px;
 }
 
 .project-card-title {
   font-weight: 700;
   font-size: var(--font-size-base);
-  margin: 0 0 4px;
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
 }
 
 .project-card-desc {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   margin: 0;
+  line-height: 1.5;
 }
 
 @media (max-width: 600px) {
@@ -291,20 +398,30 @@ section {
 .experience-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .experience-item {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  padding: 12px 16px;
+  padding: 16px 20px;
   border-radius: var(--border-radius);
-  background-color: var(--color-card-bg);
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-card-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: all 0.3s ease;
+}
+
+.experience-item:hover {
+  border-color: var(--color-link);
+  box-shadow: 0 4px 16px var(--color-card-shadow);
+  transform: translateY(-2px);
 }
 
 .experience-item .role {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .experience-item .company {
@@ -321,10 +438,11 @@ section {
 
 /* --- Footer --- */
 footer {
-  text-align: right;
+  text-align: center;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
-  padding-top: 16px;
+  padding-top: 24px;
+  margin-top: 16px;
   border-top: 1px solid var(--color-border);
 }
 
@@ -333,7 +451,10 @@ span.highlight {
   background-color: var(--color-highlight);
 }
 
-/* --- Lato Font Faces --- */
+/* --- Inter Font --- */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* --- Lato Font Faces (fallback) --- */
 @font-face {
   font-family: 'Lato';
   font-style: italic;


### PR DESCRIPTION
## Summary
- Replace table-based Jon Barron template with semantic HTML + CSS Grid/Flexbox
- Add gradient background, glassmorphism cards, scroll-triggered fade-in animations
- Project cards with real thumbnails and descriptions instead of plain links
- Experience section with descriptions and dates from resume
- Contact links as styled pills with hover fill effect
- Dark mode toggle button (top-right corner) with localStorage persistence, defaults to OS preference
- Bio updated to reflect AI engineering interests
- Inter font, refined color palette, Open Graph meta tags

## Old site
Archived at `/v1/` on main before this merge.

## Test plan
- [ ] Open `index.html` locally — verify all sections render
- [ ] Check all project card links navigate correctly
- [ ] Resize to mobile width (<600px) — verify responsive stacking
- [ ] Click dark mode toggle — verify colors switch and persist on reload
- [ ] Verify scroll animations trigger on each section